### PR TITLE
Fixed popupPM init/reinit process to avoid attaching same bindings multiple times

### DIFF
--- a/packages/nexus-bridge/src/index.js
+++ b/packages/nexus-bridge/src/index.js
@@ -164,22 +164,11 @@ export default class Nexus extends NexusBaseApplet {
   }
 
   reInitPopup() {
-    this.nexusPopupController.isPopupHidden = false
-
-    const popupPM = window.SiebelApp.S_App.GetPopupPM()
-    popupPM.Init()
-    popupPM.Setup()
+    this.nexusPopupController.reInitPopupPM()
   }
 
   static ReInitPopup() {
-    // if (window.SiebelAppFacade.NexusProcessNewPopup) {
-    //   window.SiebelApp.S_App.ProcessNewPopup =
-    //     window.SiebelAppFacade.NexusProcessNewPopup
-    //   window.SiebelAppFacade.NexusProcessNewPopup = null
-    // }
-    const popupPM = window.SiebelApp.S_App.GetPopupPM()
-    popupPM.Init()
-    popupPM.Setup()
+    NexusPopupController.instance.reInitPopupPM()
   }
 
   static CreatePopupNB(settings) {


### PR DESCRIPTION
As per investigation calling popupPM.Init/Setup multiple times doesn't work well. PM.AddMethod does not clear bindings previously attached by PopupRenderer.AttachPMBinding and causes memory leak by keeping scopes of all previously created PRs.

All props/methods of particular PM are stored inside of BasePM class and can be cleared only by BasePM.EndLife method. After props/methods are cleared they should be recreated by constructor. This approach has been implemented and tested with following scenarios:

1. Popups are working after switching between 2 views (with/without Nexus in any combo).
2. PR.ProcessStandAlonePopup is triggered only once after switching between views.
3. If Siebel native popup caused navigation to another view then it is cleared properly after navigation.
4. No visual glitches in native popups opened by reinitialized PM/PR.