### PR TITLE
Allow nested popups

### DIFF
--- a/packages/nexus-bridge/src/NexusPopupController.js
+++ b/packages/nexus-bridge/src/NexusPopupController.js
@@ -278,7 +278,7 @@ export default class NexusPopupController {
     // This is a quite common situation when invoked method fails due to some server or
     // validation errors, so popup won't even open in this case.
     const result = nb.pm.ExecuteMethod('InvokeMethod', methodName)
-    console.log('hello')
+
     // can call EditField if EditPopup?
 
     if (hide) {

--- a/packages/nexus-bridge/src/index.js
+++ b/packages/nexus-bridge/src/index.js
@@ -18,33 +18,22 @@ export default class Nexus extends NexusBaseApplet {
     return this.nexusPopupController.closePopupApplet(nb)
   }
 
-  _showPopupApplet(name, hide, cb) {
+  showPopupApplet(method, hide, cb) {
     if (!this.nexusPopupController.canOpenPopup()) {
       throw new Error(
         '[NB] Cannot open popup (currently exists resolve function)'
       )
     }
-    this._setActiveControl(name)
-    return this.nexusPopupController.showPopupApplet(
-      hide,
-      cb,
-      this,
-      'EditPopup'
-    )
+    return this.nexusPopupController.showPopupApplet(hide, cb, this, method)
+  }
+
+  _showEditPopup(controlName, hide, cb) {
+    this._setActiveControl(controlName)
+    return this.showPopupApplet('EditPopup', hide, cb)
   }
 
   changeRecords(hide, cb) {
-    if (!this.nexusPopupController.canOpenPopup()) {
-      throw new Error(
-        '[NB] Cannot open popup (currently exists resolve function)'
-      )
-    }
-    return this.nexusPopupController.showPopupApplet(
-      hide,
-      cb,
-      this,
-      'ChangeRecords'
-    )
+    this.showPopupApplet('ChangeRecords', hide, cb)
   }
 
   showMvgApplet(name, hide, cb) {
@@ -63,7 +52,7 @@ export default class Nexus extends NexusBaseApplet {
     if (this.pm.Get('IsInQueryMode')) {
       throw new Error('[NB] Mvg applet cannot be opened in query mode')
     }
-    return this._showPopupApplet(name, hide, cb)
+    return this._showEditPopup(name, hide, cb)
   }
 
   showPickApplet(name, hide, cb) {
@@ -79,7 +68,7 @@ export default class Nexus extends NexusBaseApplet {
         `Control ${name} is not of supported type ${uiType} to show Pick applet`
       )
     }
-    return this._showPopupApplet(name, hide, cb)
+    return this._showEditPopup(name, hide, cb)
   }
 
   _newAssocRecord() {


### PR DESCRIPTION
As @OllegK mentioned in issue #122 the solution is quite trivial and simple. We have to remove `checkOpenedPopup` checks and slightly fix `processNewPopup` method by clearing `currPopups` property in PopupPM, so it could be filled with nested popup's applets.

This solution was tested for about six months in production env without any issue so far.

Some tested combos:
- popups with form applet containing pick fields and MVG fields
- MVG fields with the ability to create a new record in a nested popup

Also, the "new" method `showPopupApplet` was exposed on NexusBridge instances. This allows opening any kind of popup which is a result of method execution.

Closes #122